### PR TITLE
Add github CI for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,21 +48,12 @@ jobs:
       - name: Build (Release)
         run: dotnet build . --configuration Release --no-restore -p:Version=$GitVersion_SemVer
         working-directory: ./ModernCamera
-      
-      - name: List files in current and parent directory
-        run: |
-          echo "Listing files in current directory:"
-          ls -al
-          echo "Listing files in parent directory:"
-          ls -al ..
-          echo "Listing files in moderncamera directory:"
-          ls -al ./ModernCamera
-          echo "Listing files in home directory:"
-          ls -al ~
+
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.0
         with:
-          path: ../package/
+          path: ./ModernCamera/package/
+          if-no-files-found: error
 
       - name: GH Release
         uses: softprops/action-gh-release@v1
@@ -70,7 +61,7 @@ jobs:
         with:
           body: Automatic pre-release of ${{ env.GitVersion_SemVer }} for ${{ env.GitVersion_ShortSha }}
           name: v${{ env.GitVersion_SemVer }}
-          files: ./package/*
+          files: ./ModernCamera/package/*
           fail_on_unmatched_files: true
           prerelease: true
           tag_name: v${{ env.GitVersion_SemVer }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,17 @@ jobs:
       - name: Build (Release)
         run: dotnet build . --configuration Release --no-restore -p:Version=$GitVersion_SemVer
         working-directory: ./ModernCamera
-
+      
+      - name: List files in current and parent directory
+        run: |
+          echo "Listing files in current directory:"
+          ls -al
+          echo "Listing files in parent directory:"
+          ls -al ..
+          echo "Listing files in moderncamera directory:"
+          ls -al ./ModernCamera
+          echo "Listing files in home directory:"
+          ls -al ~
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+name: Build
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: 6.0.x
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: "5.x"
+      
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ./ModernCamera
+
+      - name: Checkout Silkworm
+        uses: actions/checkout@v3
+        with:
+          repository: iZastic/vrising-silkworm
+          path: ./Silkworm
+      
+      - name: Restore dependencies
+        run: dotnet restore
+        working-directory: ./ModernCamera
+
+      - name: Determine Version
+        uses: gittools/actions/gitversion/execute@v0.9.7
+        with:
+          additionalArguments: '/updateprojectfiles /overrideconfig "mode=Mainline"'
+
+      - name: Build (Release)
+        run: dotnet build . --configuration Release --no-restore -p:Version=$GitVersion_SemVer
+        working-directory: ./ModernCamera
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v3.1.0
+        with:
+          path: ./package
+
+      - name: GH Release
+        uses: softprops/action-gh-release@v1
+        if: github.event_name == 'push'
+        with:
+          body: Automatic pre-release of ${{ env.GitVersion_SemVer }} for ${{ env.GitVersion_ShortSha }}
+          name: v${{ env.GitVersion_SemVer }}
+          files: ./package/*
+          fail_on_unmatched_files: true
+          prerelease: true
+          tag_name: v${{ env.GitVersion_SemVer }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v0.9.7
         with:
           additionalArguments: '/updateprojectfiles /overrideconfig "mode=Mainline"'
-          targetPath: '../'
+          targetPath: './ModernCamera'
 
       - name: Build (Release)
         run: dotnet build . --configuration Release --no-restore -p:Version=$GitVersion_SemVer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ./ModernCamera
+          fetch-depth: 0
 
       - name: Checkout Silkworm
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,7 @@ jobs:
         uses: gittools/actions/gitversion/execute@v0.9.7
         with:
           additionalArguments: '/updateprojectfiles /overrideconfig "mode=Mainline"'
+          targetPath: '../'
 
       - name: Build (Release)
         run: dotnet build . --configuration Release --no-restore -p:Version=$GitVersion_SemVer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v3.1.0
         with:
-          path: ./package
+          path: ../package/
 
       - name: GH Release
         uses: softprops/action-gh-release@v1

--- a/ModernCamera/NuGet.Config
+++ b/ModernCamera/NuGet.Config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="BepInEx" value="https://nuget.bepinex.dev/v3/index.json" />
+    <add key="Samboy Feed" value="https://nuget.samboy.dev/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This attempts to handle the way Silkworm is referenced without needing to adjust the build or structure of either project.